### PR TITLE
Fix marketplace plugin source path traversal error

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       {
         "name": "notion-workspace-plugin",
         "description": "One-click install for Notion Skills + Notion MCP server.",
-        "source": "../",
+        "source": "./",
         "homepage": "https://www.notion.so"
       }
     ]


### PR DESCRIPTION
Change source from "../" to "./" since path traversal is not allowed in Claude Code plugin sources. Paths are relative to repo root.

<img width="573" height="123" alt="image" src="https://github.com/user-attachments/assets/d342cfc1-275b-4b72-af84-bdf1c43dd151" />

