### PR TITLE
Fix marketplace source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,10 @@
       {
         "name": "notion-workspace-plugin",
         "description": "One-click install for Notion Skills + Notion MCP server.",
-        "source": "../",
+        "source": {
+          "source": "github",
+          "repo": "makenotion/claude-code-notion-plugin"
+        },
         "homepage": "https://www.notion.so"
       }
     ]


### PR DESCRIPTION
### Problem

Running `/plugin marketplace add makenotion/claude-code-notion-plugin` fails with:

Error: Invalid schema: plugins.0.source: Invalid input

<img width="1320" height="334" alt="CleanShot 2026-01-21 at 11 39 20@2x" src="https://github.com/user-attachments/assets/9707be27-bb3e-4f1d-b628-cc9b8f04f9b3" />


### Root Cause

The `source` field in `marketplace.json` was set to `"../"`, which is not a valid source format. Claude Code's plugin schema requires source to be
one of:
- A relative path starting with `./`
- A structured object like `{ "source": "github", "repo": "owner/repo" }`
- A URL object like `{ "source": "url", "url": "https://..." }`

The path `"../"` fails schema validation because it doesn't match any of these formats.

### Fix

Changed the source from a relative path to an explicit GitHub source object:

```json
"source": {
  "source": "github", "repo": "makenotion/claude-code-notion-plugin" }
```

### Testing

I manually tested this fixed version and it seems to work:

<img width="1754" height="282" alt="CleanShot 2026-01-21 at 11 39 12@2x" src="https://github.com/user-attachments/assets/e0c705c3-2c99-4afe-9ccf-c41c65e3c689" />
