### PR TITLE
fix: align plugin.json name with marketplace.json entry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     },
     "plugins": [
       {
-        "name": "notion-workspace-plugin",
+        "name": "Notion",
         "description": "One-click install for Notion Skills + Notion MCP server.",
         "source": {
           "source": "github",


### PR DESCRIPTION
## Summary

- Aligns `plugin.json` `"name"` field (`"Notion"`) with `marketplace.json` plugin entry (`"notion-workspace-plugin"`)
- This mismatch causes `/plugin` update and info lookups to fail with `"Plugin Notion not found in marketplace"`

## Root Cause

The `/plugin` menu resolves plugins by the marketplace-level name (`notion-workspace-plugin`), but displays the name from `plugin.json` (`Notion`). When triggering update/info, it looks up `"Notion"` and can't find a match.

Fixes #16